### PR TITLE
Face fixture wrap fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,13 @@
     "edu.wpi.first.math.**.proto.*",
     "edu.wpi.first.math.**.struct.*",
   ],
-  "java.dependency.enableDependencyCheckup": false
+  "java.dependency.enableDependencyCheckup": false,
+  "cSpell.words": [
+    "Deadband",
+    "feedforwards",
+    "Holonomic",
+    "Photonvision",
+    "Pidgey",
+    "teleop"
+  ]
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -144,4 +144,8 @@ public final class Constants {
         public static final AprilTagFieldLayout kTagLayout
                 = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
     }
+
+    public static final class NumericalConstants {
+        public static final double kEpsilon = 1e-6;
+    }
 }

--- a/src/main/java/frc/robot/Meters.java
+++ b/src/main/java/frc/robot/Meters.java
@@ -1,0 +1,5 @@
+package frc.robot;
+
+public class Meters {
+
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,6 +6,7 @@ package frc.robot;
 import com.pathplanner.lib.commands.PathPlannerAuto;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -14,7 +15,6 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.OIConstants;
 import frc.robot.subsystems.DriveSubsystem;
-import static edu.wpi.first.units.Units.*;
 
 public class RobotContainer {
 
@@ -46,7 +46,7 @@ public class RobotContainer {
     }
 
     private void configureBindings() {
-        m_driverController.x().whileTrue(m_drive.moveToAngle(Radians.of(Math.PI)));
+        m_driverController.x().whileTrue(m_drive.enableFacePose(new Pose2d()));
         m_driverController.x().whileFalse(m_drive.disableFacePose());
     }
 


### PR DESCRIPTION
Fixes #12 by wrapping both angles to a unit circle with the target position relative to the robot represented by angles [-π, π] which always give the shortest angular distance to the corresponding point on the unit circle. The difference is reapplied to the robot's current unbound heading in order to give an accurate set point to the PID controller.